### PR TITLE
added option to set ckeditor.height

### DIFF
--- a/core/components/ckeditor/lexicon/de/default.inc.php
+++ b/core/components/ckeditor/lexicon/de/default.inc.php
@@ -28,3 +28,5 @@ $_lang['setting_ckeditor.autocorrect_double_quotes'] = 'Anführungszeichen';
 $_lang['setting_ckeditor.autocorrect_double_quotes_desc'] = 'A pair of opening and closing marks to convert typewriter quotation marks to (smart quotes). In english writing “curly quotes” are used.';
 $_lang['setting_ckeditor.autocorrect_single_quotes'] = 'einfache Anführungszeichen';
 $_lang['setting_ckeditor.autocorrect_single_quotes_desc'] = 'A pair of opening and closing marks to convert typewriter apostrophes to (smart quotes). In english writing ‘curly quotes’ are used.';
+$_lang['setting_ckeditor.height'] = 'Editor Höhe';
+$_lang['setting_ckeditor.height_desc'] = 'Höhe des Editor-Feldes in Pixeln.';

--- a/core/components/ckeditor/lexicon/en/default.inc.php
+++ b/core/components/ckeditor/lexicon/en/default.inc.php
@@ -36,3 +36,5 @@ $_lang['setting_ckeditor.remove_plugins'] = 'Remove plugins';
 $_lang['setting_ckeditor.remove_plugins_desc'] = 'List of plugins to exclude, separated by «,».';
 $_lang['setting_ckeditor.native_spellchecker'] = 'Native spellchecker';
 $_lang['setting_ckeditor.native_spellchecker_desc'] = 'Enables the built-in words spell checker if browser provides one.';
+$_lang['setting_ckeditor.height'] = 'Editor height';
+$_lang['setting_ckeditor.height_desc'] = 'Height of the editor field in pixels.';

--- a/manager/assets/components/ckeditor/modx.htmleditor.js
+++ b/manager/assets/components/ckeditor/modx.htmleditor.js
@@ -115,6 +115,7 @@ MODx.ux.CKEditor = Ext.extend(Ext.ux.CKEditor, {
         dialog_backgroundCoverColor:    'silver',
         dialog_backgroundCoverOpacity:  '0.5',
         filebrowserBrowseUrl:           getFileBrowseUrl(),
+        height:							getOption('ckeditor.height', 'number'),
         //keystrokes:             [], // TODO !!!
         //menu_groups: 'clipboard,table,anchor,link,image', // TODO !!!
     },
@@ -332,7 +333,7 @@ MODx.ux.CKEditor.replaceElement = function(element) {
     var htmlEditor = MODx.load({
         xtype: 'modx-htmleditor',
         width: 'auto',
-        height: parseInt(element.height, 10) || 200,
+        height: parseInt(element.height, 10) || getOption('ckeditor.height', 'number'),
         applyTo: element,
         value: element.value || '<p></p>',
         droppable: true


### PR DESCRIPTION
Might come handy to be able to set the height of the editor field. (instead of the hardcoded 200px)
Obviously needs an additional setting in ckeditor's system settings. I'm no package ninja but maybe someone else can add this to the setup/install procedure. 
