### PR TITLE
Add: new setting: Force Paste as Plain Text

### DIFF
--- a/_build/data/transport.settings.php
+++ b/_build/data/transport.settings.php
@@ -127,4 +127,14 @@ $settings['resource_editor_height']->fromArray(array(
         'area' => 'general'
     ),'',true,true);
 
+$settings['force_paste_plain_text']= $modx->newObject('modSystemSetting');
+$settings['force_paste_plain_text']->fromArray(array(
+        'key' => 'ckeditor.force_paste_plain_text',
+        'xtype' => 'textfield',
+        'type' => 'list',
+        'value' => 'false', //'true', 'allow-word', 'false'
+        'namespace' => 'ckeditor',
+        'area' => 'general',
+    ),'',true,true);
+
 return $settings;

--- a/core/components/ckeditor/lexicon/en/default.inc.php
+++ b/core/components/ckeditor/lexicon/en/default.inc.php
@@ -36,5 +36,7 @@ $_lang['setting_ckeditor.remove_plugins'] = 'Remove plugins';
 $_lang['setting_ckeditor.remove_plugins_desc'] = 'List of plugins to exclude, separated by «,».';
 $_lang['setting_ckeditor.native_spellchecker'] = 'Native spellchecker';
 $_lang['setting_ckeditor.native_spellchecker_desc'] = 'Enables the built-in words spell checker if browser provides one.';
+$_lang['setting_ckeditor.force_paste_plain_text'] = 'Force Paste as Plain Text';
+$_lang['setting_ckeditor.force_paste_plain_text_desc'] = 'Whether to force all pasting operations to insert plain text into the editor, losing any formatting information possibly available in the source text. Possible values: "true": force plain text, "false": allow all formatting, "allow-word": All formatting is removed, except formatting from Microsoft Word (needs pastefromword plugin).';
 $_lang['setting_ckeditor.resource_editor_height'] = 'Resource editor height';
 $_lang['setting_ckeditor.resource_editor_height_desc'] = 'Resource (document) content editor height adjustment';

--- a/manager/assets/components/ckeditor/modx.htmleditor.js
+++ b/manager/assets/components/ckeditor/modx.htmleditor.js
@@ -75,6 +75,15 @@ function getOption(key, type, defaultValue) {
         'json': JSON.parse
     };
     try {
+        if ( 'boolean_or_string' === type ) {
+            if ( 'true' === raw.toLowerCase() ) {
+                return true;
+            }
+            if ( 'false' === raw.toLowerCase() ) {
+                return false;
+            }
+            type = 'string';
+        }
         return types[type](raw);
     } catch (e) {
         return defaultValue;
@@ -86,6 +95,8 @@ function getFileBrowseUrl() {
     var query = {a: MODx.action['browser'], source: MODx.config['default_media_source']};
     return url + '?' + Ext.urlEncode(query);
 }
+
+var force_paste_plain_text = getOption('ckeditor.force_paste_plain_text', 'boolean_or_string', false);
 
 MODx.ux.CKEditor = Ext.extend(Ext.ux.CKEditor, {
     droppable: false,
@@ -99,7 +110,7 @@ MODx.ux.CKEditor = Ext.extend(Ext.ux.CKEditor, {
         toolbarGroups:                  getOption('ckeditor.toolbar_groups', 'json'),
         format_tags:                    getOption('ckeditor.format_tags', 'string'),
         extraPlugins:                   getOption('ckeditor.extra_plugins', 'string'),
-        removePlugins:                  getOption('ckeditor.remove_plugins', 'string'),
+        removePlugins:                  getOption('ckeditor.remove_plugins', 'string') + (force_paste_plain_text === true ? ',pastefromword' : ''),
         stylesSet:                      getOption('ckeditor.styles_set', 'json', MODx.config['ckeditor.styles_set']),
         startupMode:                    getOption('ckeditor.startup_mode', 'string'),
         undoStackSize:                  getOption('ckeditor.undo_size', 'number'),
@@ -108,6 +119,7 @@ MODx.ux.CKEditor = Ext.extend(Ext.ux.CKEditor, {
         autocorrect_singleQuotes:       getOption('ckeditor.autocorrect_single_quotes', 'string'),
         disableObjectResizing:          !getOption('ckeditor.object_resizing', 'boolean'),
         disableNativeSpellChecker:      !getOption('ckeditor.native_spellchecker', 'boolean'),
+        forcePasteAsPlainText:          force_paste_plain_text,
         entities:                       false,
         autoParagraph:                  false,
         magicline_putEverywhere:        true,


### PR DESCRIPTION
Title really tells it all.
modx.htmleditor.js got a bit hackish as despite `'allow-word'` setting is a [built-in option for CKEditor](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-forcePasteAsPlainText), `true` only really works any different than `'allow-word'` if the `pastefromword` plugin is disabled at the same time. Also because `forcePasteAsPlainText` can both be boolean and string.
Tested on ModX v2.7.2-pl, builds fine and works as advertised.